### PR TITLE
Add dark mode theme toggle

### DIFF
--- a/financial_cyber_secure.html
+++ b/financial_cyber_secure.html
@@ -6,15 +6,33 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Financial Cyber Secure</title>
     <style>
+        :root {
+            --bg-color: #f4f4f4;
+            --text-color: #333;
+            --primary-color: #004080;
+            --secondary-color: #003366;
+            --hover-color: #002244;
+            --card-bg: #ffffff;
+        }
+
+        [data-theme="dark"] {
+            --bg-color: #121212;
+            --text-color: #f4f4f4;
+            --primary-color: #1a8bc5;
+            --secondary-color: #0d4a6f;
+            --hover-color: #1a8bc5;
+            --card-bg: #1e1e1e;
+        }
+
         body {
             font-family: Arial, sans-serif;
             margin: 0;
             padding: 0;
-            background-color: #f4f4f4;
-            color: #333;
+            background-color: var(--bg-color);
+            color: var(--text-color);
         }
         header {
-            background: #004080;
+            background: var(--primary-color);
             color: white;
             padding: 20px;
             text-align: center;
@@ -22,7 +40,8 @@
         nav {
             display: flex;
             justify-content: center;
-            background: #003366;
+            align-items: center;
+            background: var(--secondary-color);
             padding: 10px;
         }
         nav a {
@@ -32,18 +51,32 @@
             font-size: 18px;
         }
         nav a:hover {
-            background: #002244;
+            background: var(--hover-color);
+        }
+        .toggle-btn {
+            cursor: pointer;
+            border: none;
+            background: var(--primary-color);
+            color: white;
+            padding: 10px 20px;
+            font-size: 18px;
+            border-radius: 5px;
+            margin-left: 20px;
+            transition: background 0.3s ease;
+        }
+        .toggle-btn:hover {
+            background: var(--hover-color);
         }
         section {
             padding: 20px;
             max-width: 900px;
             margin: auto;
-            background: white;
+            background: var(--card-bg);
             box-shadow: 0px 0px 10px #aaa;
             margin-top: 20px;
         }
         footer {
-            background: #004080;
+            background: var(--primary-color);
             color: white;
             text-align: center;
             padding: 10px;
@@ -55,14 +88,15 @@
         .btn {
             display: inline-block;
             padding: 10px 20px;
-            background: #004080;
+            background: var(--primary-color);
             color: white;
             text-decoration: none;
             margin-top: 10px;
             border-radius: 5px;
+            transition: background 0.3s ease;
         }
         .btn:hover {
-            background: #002244;
+            background: var(--hover-color);
         }
     </style>
 </head>
@@ -77,6 +111,7 @@
         <a href="#about">About</a>
         <a href="#services">Services</a>
         <a href="#contact">Contact</a>
+        <button id="toggleTheme" class="toggle-btn">Dark Mode</button>
     </nav>
 
     <section id="about">
@@ -107,6 +142,21 @@
     <footer>
         <p>© 2025 Financial Cyber Secure. All Rights Reserved.</p>
     </footer>
+    <script>
+        const themeBtn = document.getElementById('toggleTheme');
+        const root = document.documentElement;
+        const storedTheme = localStorage.getItem('theme');
+        if (storedTheme === 'dark') {
+            root.dataset.theme = 'dark';
+            themeBtn.textContent = 'Light Mode';
+        }
+        themeBtn.addEventListener('click', () => {
+            const isDark = root.dataset.theme === 'dark';
+            root.dataset.theme = isDark ? '' : 'dark';
+            themeBtn.textContent = isDark ? 'Dark Mode' : 'Light Mode';
+            localStorage.setItem('theme', root.dataset.theme);
+        });
+    </script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add CSS variables and dark mode palette to financial_cyber_secure.html
- include theme toggle button and persistence via localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68993ab01d2c83308d527408d7596a12